### PR TITLE
feat: scaffold monorepo with audio worker and router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+pnpm-lock.yaml
+.env
+**/dist
+**/build
+__pycache__
+.env.local
+.DS_Store

--- a/apps/router/package.json
+++ b/apps/router/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "router",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "node-fetch": "^3.3.2",
+    "ioredis": "^5.3.1",
+    "form-data": "^4.0.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  }
+}

--- a/apps/router/src/index.ts
+++ b/apps/router/src/index.ts
@@ -1,0 +1,30 @@
+import express from "express";
+import fetch from "node-fetch";
+import Redis from "ioredis";
+import FormData from "form-data";
+
+const r = new Redis(process.env.REDIS_URL!);
+const app = express();
+app.use(express.json({ limit: "5mb" }));
+
+type Turn = { userHint?: string; chunkUrl: string; sessionId: string };
+
+app.post("/route", async (req, res) => {
+  const { userHint, chunkUrl, sessionId } = req.body as Turn;
+
+  // send audio to audio-worker
+  const audio = await fetch(chunkUrl);
+  const blob = await audio.arrayBuffer();
+  const form = new FormData();
+  form.append("file", Buffer.from(blob), {
+    filename: "a.wav"
+  });
+  const resp = await fetch(process.env.AUDIO_WORKER_URL + "/infer", { method: "POST", body: form as any });
+  const { label, confidence, f0_mean, rms } = await resp.json();
+
+  const finalLabel = userHint ?? (confidence > 0.55 ? label : "unknown");
+  await r.lpush(`sess:${sessionId}:turns:${finalLabel}`, JSON.stringify({ ts: Date.now(), chunkUrl, f0_mean, rms }));
+  res.json({ speaker: finalLabel, confidence, f0_mean, rms });
+});
+
+app.listen(8080, () => console.log("router up"));

--- a/apps/router/tsconfig.json
+++ b/apps/router/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.2.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <main>
+      <h1>multi-combo</h1>
+      <p>Push-to-talk demo coming soon.</p>
+    </main>
+  );
+}

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  redis:
+    image: redis:7
+    ports:
+      - '6379:6379'
+  audio-worker:
+    build: ../../services/audio-worker
+    ports:
+      - '8001:8001'

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,3 @@
+# Terraform Infrastructure
+
+Provisioning scripts for AWS resources will live here.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "multi-combo",
+  "private": true,
+  "packageManager": "pnpm@8.15.4",
+  "scripts": {
+    "dev": "turbo dev"
+  },
+  "devDependencies": {
+    "turbo": "^1.10.12"
+  }
+}

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@multi-combo/proto",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts"
+}

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -1,0 +1,5 @@
+export type Turn = {
+  userHint?: string;
+  chunkUrl: string;
+  sessionId: string;
+};

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - 'apps/*'
+  - 'services/*'
+  - 'packages/*'

--- a/services/audio-worker/Dockerfile
+++ b/services/audio-worker/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/services/audio-worker/app.py
+++ b/services/audio-worker/app.py
@@ -1,0 +1,56 @@
+from fastapi import FastAPI, UploadFile
+from pydantic import BaseModel
+import torch, librosa, numpy as np
+from speechbrain.pretrained import EncoderClassifier
+import uvicorn, io, soundfile as sf
+
+app = FastAPI()
+model = EncoderClassifier.from_hparams(
+    source="speechbrain/spkrec-ecapa-voxceleb", run_opts={"device":"cpu"}
+)
+
+enrolled = {}  # user_id -> embedding np.array
+
+def wav_to_np(file: UploadFile):
+    raw = io.BytesIO(file.file.read())
+    y, sr = sf.read(raw, dtype='float32')
+    if y.ndim > 1: y = np.mean(y, axis=1)
+    return y, sr
+
+def embed(y, sr):
+    tensor = torch.tensor(y).unsqueeze(0)
+    with torch.no_grad():
+        emb = model.encode_batch(tensor).squeeze(0).squeeze(0).cpu().numpy()
+    return emb / np.linalg.norm(emb)
+
+def pitch_energy(y, sr):
+    f0 = librosa.yin(y, fmin=50, fmax=400, sr=sr)
+    rms = librosa.feature.rms(y=y).mean()
+    return float(np.nanmean(f0)), float(rms)
+
+@app.post("/enroll/{user_id}")
+async def enroll(user_id: str, file: UploadFile):
+    y, sr = wav_to_np(file)
+    enrolled[user_id] = embed(y, sr)
+    return {"ok": True}
+
+class InferResp(BaseModel):
+    label: str
+    confidence: float
+    f0_mean: float
+    rms: float
+
+@app.post("/infer", response_model=InferResp)
+async def infer(file: UploadFile):
+    y, sr = wav_to_np(file)
+    e = embed(y, sr)
+    scores = {u: float(np.dot(e, v)) for u,v in enrolled.items()}
+    if scores:
+        label, conf = max(scores.items(), key=lambda kv: kv[1])
+    else:
+        label, conf = "S?", 0.0
+    f0, rms = pitch_energy(y, sr)
+    return {"label": label, "confidence": conf, "f0_mean": f0, "rms": rms}
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8001)

--- a/services/audio-worker/requirements.txt
+++ b/services/audio-worker/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+torch
+librosa
+numpy
+speechbrain
+soundfile

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "build/**"]
+    },
+    "dev": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- set up pnpm/turbo monorepo structure
- add FastAPI audio-worker with speaker embedding & pitch extraction
- add Express router service to forward audio chunks and log turns
- stub Next.js web app and infra scaffolding

## Testing
- `python -m py_compile services/audio-worker/app.py`
- `npx tsc -p apps/router/tsconfig.json --noEmit` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b69f4f4bb08327b1681e4aa36640d8