### PR TITLE
feat: add WebSocket push-to-talk demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+pnpm-lock.yaml
+.env
+**/dist
+**/build
+.next
+__pycache__
+.env.local
+.DS_Store

--- a/apps/router/package.json
+++ b/apps/router/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "router",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "ioredis": "^5.3.1",
+    "ws": "^8.13.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2",
+    "@types/express": "^4.17.21",
+    "@types/node": "^18.16.3",
+    "@types/ws": "^8.5.8"
+  }
+}

--- a/apps/router/src/index.ts
+++ b/apps/router/src/index.ts
@@ -1,0 +1,47 @@
+import express from "express";
+import { createServer } from "http";
+import { WebSocketServer } from "ws";
+import Redis from "ioredis";
+
+const r = new Redis(process.env.REDIS_URL!);
+const app = express();
+app.get("/health", (_, res) => res.send("ok"));
+
+interface InMsg {
+  sessionId: string;
+  userHint?: string;
+  chunk: string; // base64 encoded audio
+}
+
+interface WorkerResp {
+  label: string;
+  confidence: number;
+  f0_mean: number;
+  rms: number;
+}
+
+const server = createServer(app);
+const wss = new WebSocketServer({ server, path: "/route" });
+
+wss.on("connection", ws => {
+  ws.on("message", async raw => {
+    try {
+      const { sessionId, userHint, chunk } = JSON.parse(raw.toString()) as InMsg;
+      const buf = Buffer.from(chunk, "base64");
+      const form = new FormData();
+      form.append("file", new Blob([buf]), "a.wav");
+      const resp = await fetch(process.env.AUDIO_WORKER_URL + "/infer", { method: "POST", body: form });
+      const { label, confidence, f0_mean, rms } = (await resp.json()) as WorkerResp;
+      const finalLabel = userHint ?? (confidence > 0.55 ? label : "unknown");
+      await r.lpush(
+        `sess:${sessionId}:turns:${finalLabel}`,
+        JSON.stringify({ ts: Date.now(), f0_mean, rms })
+      );
+      ws.send(JSON.stringify({ speaker: finalLabel, confidence, f0_mean, rms }));
+    } catch (err) {
+      ws.send(JSON.stringify({ error: "processing_failed" }));
+    }
+  });
+});
+
+server.listen(8080, () => console.log("router ws up"));

--- a/apps/router/tsconfig.json
+++ b/apps/router/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/apps/web/components/useSpeak.ts
+++ b/apps/web/components/useSpeak.ts
@@ -1,0 +1,26 @@
+// useSpeak.ts — hook that reads text using browser TTS
+
+import { useEffect, useRef } from 'react'
+
+export function useSpeak(text: string | null) {
+  const synthRef = useRef<SpeechSynthesisUtterance | null>(null)
+
+  useEffect(() => {
+    if (!text) return
+
+    const utter = new SpeechSynthesisUtterance(text)
+    utter.lang = 'en-US'
+    utter.rate = 1.0
+    utter.pitch = 1.0
+    utter.volume = 1.0
+
+    const voice = speechSynthesis
+      .getVoices()
+      .find(v => v.name.includes('Google') || v.lang === 'en-US')
+
+    if (voice) utter.voice = voice
+
+    synthRef.current = utter
+    speechSynthesis.speak(utter)
+  }, [text])
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.2.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.25",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "typescript": "^5.4.2"
+  }
+}

--- a/apps/web/pages/demo.tsx
+++ b/apps/web/pages/demo.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react'
+import { useSpeak } from '../components/useSpeak'
+
+export default function DemoTTS() {
+  const [input, setInput] = useState('')
+  const [spoken, setSpoken] = useState('')
+
+  useSpeak(spoken)
+
+  return (
+    <div style={{ padding: 40 }}>
+      <h1>🗣 Speak Words Locally</h1>
+      <p>Type something and hit speak. Browser will read it aloud.</p>
+
+      <input
+        value={input}
+        onChange={e => setInput(e.target.value)}
+        style={{ padding: 8, fontSize: 16, marginRight: 10 }}
+      />
+      <button onClick={() => setSpoken(input)}>Speak</button>
+    </div>
+  )
+}

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from 'react';
+
+export default function Home() {
+  const wsRef = useRef<WebSocket | null>(null);
+  const mediaRef = useRef<MediaRecorder | null>(null);
+  const activeRef = useRef<string | null>(null);
+  const [label, setLabel] = useState('');
+  const [confidence, setConfidence] = useState(0);
+  const [level, setLevel] = useState(0);
+  const sessionId = useRef(crypto.randomUUID());
+
+  useEffect(() => {
+    const wsUrl = process.env.NEXT_PUBLIC_ROUTER_WS || 'ws://localhost:8080/route';
+    const ws = new WebSocket(wsUrl);
+    ws.onmessage = ev => {
+      const msg = JSON.parse(ev.data);
+      if (msg.speaker) {
+        setLabel(msg.speaker);
+        setConfidence(msg.confidence);
+      }
+    };
+    wsRef.current = ws;
+    return () => ws.close();
+  }, []);
+
+  useEffect(() => {
+    navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
+      const mr = new MediaRecorder(stream, { mimeType: 'audio/webm' });
+      mediaRef.current = mr;
+      mr.ondataavailable = async e => {
+        if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN && activeRef.current) {
+          const buf = await e.data.arrayBuffer();
+          const bytes = new Uint8Array(buf);
+          let binary = "";
+          bytes.forEach(b => binary += String.fromCharCode(b));
+          const b64 = btoa(binary);
+          wsRef.current.send(
+            JSON.stringify({ sessionId: sessionId.current, userHint: activeRef.current, chunk: b64 })
+          );
+        }
+      };
+
+      const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+      const src = ctx.createMediaStreamSource(stream);
+      const analyser = ctx.createAnalyser();
+      analyser.fftSize = 512;
+      src.connect(analyser);
+      const data = new Uint8Array(analyser.fftSize);
+      const tick = () => {
+        analyser.getByteTimeDomainData(data);
+        let sum = 0;
+        for (let i = 0; i < data.length; i++) {
+          const v = (data[i] - 128) / 128;
+          sum += v * v;
+        }
+        setLevel(Math.sqrt(sum / data.length));
+        requestAnimationFrame(tick);
+      };
+      tick();
+    });
+  }, []);
+
+  const start = (hint: string) => {
+    if (mediaRef.current && mediaRef.current.state === 'inactive') {
+      activeRef.current = hint;
+      mediaRef.current.start(1000);
+    }
+  };
+  const stop = () => {
+    if (mediaRef.current && mediaRef.current.state === 'recording') {
+      mediaRef.current.stop();
+      activeRef.current = null;
+    }
+  };
+
+  return (
+    <main style={{ padding: 20 }}>
+      <h1>multi-combo</h1>
+      <p>Hold a button while speaking.</p>
+      <div style={{ display: 'flex', gap: 10 }}>
+        {['A', 'B', 'C'].map(h => (
+          <button
+            key={h}
+            onMouseDown={() => start(h)}
+            onMouseUp={stop}
+            onTouchStart={() => start(h)}
+            onTouchEnd={stop}
+          >
+            {h}
+          </button>
+        ))}
+      </div>
+      <div style={{ marginTop: 20, height: 10, background: '#eee', width: 200 }}>
+        <div style={{ height: '100%', width: `${Math.min(1, level) * 200}px`, background: '#0a0' }} />
+      </div>
+      <p>
+        Detected: {label || '—'} {label && `(${(confidence * 100).toFixed(1)}%)`}
+      </p>
+    </main>
+  );
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  redis:
+    image: redis:7
+    ports:
+      - '6379:6379'
+  audio-worker:
+    build: ../../services/audio-worker
+    ports:
+      - '8001:8001'

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,3 @@
+# Terraform Infrastructure
+
+Provisioning scripts for AWS resources will live here.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "multi-combo",
+  "private": true,
+  "packageManager": "pnpm@8.15.4",
+  "scripts": {
+    "dev": "turbo dev"
+  },
+  "devDependencies": {
+    "turbo": "^1.10.12"
+  }
+}

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@multi-combo/proto",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts"
+}

--- a/packages/proto/src/index.ts
+++ b/packages/proto/src/index.ts
@@ -1,0 +1,5 @@
+export type Turn = {
+  userHint?: string;
+  chunkUrl: string;
+  sessionId: string;
+};

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - 'apps/*'
+  - 'services/*'
+  - 'packages/*'

--- a/services/audio-worker/Dockerfile
+++ b/services/audio-worker/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/services/audio-worker/app.py
+++ b/services/audio-worker/app.py
@@ -1,0 +1,56 @@
+from fastapi import FastAPI, UploadFile
+from pydantic import BaseModel
+import torch, librosa, numpy as np
+from speechbrain.pretrained import EncoderClassifier
+import uvicorn, io, soundfile as sf
+
+app = FastAPI()
+model = EncoderClassifier.from_hparams(
+    source="speechbrain/spkrec-ecapa-voxceleb", run_opts={"device":"cpu"}
+)
+
+enrolled = {}  # user_id -> embedding np.array
+
+def wav_to_np(file: UploadFile):
+    raw = io.BytesIO(file.file.read())
+    y, sr = sf.read(raw, dtype='float32')
+    if y.ndim > 1: y = np.mean(y, axis=1)
+    return y, sr
+
+def embed(y, sr):
+    tensor = torch.tensor(y).unsqueeze(0)
+    with torch.no_grad():
+        emb = model.encode_batch(tensor).squeeze(0).squeeze(0).cpu().numpy()
+    return emb / np.linalg.norm(emb)
+
+def pitch_energy(y, sr):
+    f0 = librosa.yin(y, fmin=50, fmax=400, sr=sr)
+    rms = librosa.feature.rms(y=y).mean()
+    return float(np.nanmean(f0)), float(rms)
+
+@app.post("/enroll/{user_id}")
+async def enroll(user_id: str, file: UploadFile):
+    y, sr = wav_to_np(file)
+    enrolled[user_id] = embed(y, sr)
+    return {"ok": True}
+
+class InferResp(BaseModel):
+    label: str
+    confidence: float
+    f0_mean: float
+    rms: float
+
+@app.post("/infer", response_model=InferResp)
+async def infer(file: UploadFile):
+    y, sr = wav_to_np(file)
+    e = embed(y, sr)
+    scores = {u: float(np.dot(e, v)) for u,v in enrolled.items()}
+    if scores:
+        label, conf = max(scores.items(), key=lambda kv: kv[1])
+    else:
+        label, conf = "S?", 0.0
+    f0, rms = pitch_energy(y, sr)
+    return {"label": label, "confidence": conf, "f0_mean": f0, "rms": rms}
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8001)

--- a/services/audio-worker/requirements.txt
+++ b/services/audio-worker/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+torch
+librosa
+numpy
+speechbrain
+soundfile

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "build/**"]
+    },
+    "dev": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add SpeechSynthesis hook for local TTS (previous)
- switch router to WebSocket endpoint for audio chunks
- implement frontend push-to-talk UI with WebRTC capture, meter, and live labels

## Testing
- `pnpm install`
- `pnpm --filter router exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter web exec next build`
- `python -m py_compile services/audio-worker/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b69f4f4bb08327b1681e4aa36640d8